### PR TITLE
[fix](jenkins): maven compiler plugin release 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<release>17</release>
+					<release>11</release>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
- reverted maven compiler plugin release 17 to 11 to resolve the incompatibility issue with jenkins.

Signed-off-by: LetsGoRichard <richardaw13032001@gmail.com>